### PR TITLE
Check if custom element is already defined before defining it

### DIFF
--- a/src/x-component.js
+++ b/src/x-component.js
@@ -288,6 +288,7 @@ ${elScript.innerHTML}
                 }
             })
         }
+        if (!customElements.get(compName.toLowerCase())) {
         $vui.components[compName] = class extends HTMLElement {
             connectedCallback() {
                 let elComp = this
@@ -402,5 +403,6 @@ ${elScript.innerHTML}
             }
         }
         customElements.define(compName.toLowerCase(), $vui.components[compName]);
+        }
     })
 })


### PR DESCRIPTION
- Added a conditional check using `customElements.get()` to verify if the custom element is already defined.
- Prevents `DOMException` by ensuring elements are not redefined when using Pinecone router that fetch content from url
- Ensured compatibility and stability by avoiding duplicate element definitions.